### PR TITLE
Document why, how, and what for RuboCop::Packaging

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -221,3 +221,30 @@ require 'foo.rb'
 require_relative 'spec_helper'
 require_relative 'foo/bar'
 ----
+
+
+== Contributing
+
+The guide is still a work in progress - new cops are being added, existing ones are being
+refactored. And whilst doing so, some bits might need a little more polishing and
+paraphrasing to make things clearer. +
+Improving such guidelines is a great (and simple way) to help the Ruby community!
+
+Also, nothing written in this guide is set in stone. We desire to work together with
+everyone interested in Ruby coding style, so that we could ultimately create a resource that
+will be beneficial to the entire Ruby community!
+
+Feel free to open issues or send pull requests with improvements. Thanks in advance for your
+help!
+
+=== How to Contribute?
+
+It's easy, just follow the contribution guidelines below:
+
+* https://help.github.com/articles/fork-a-repo[Fork]
+  https://github.com/utkarsh2102/rubocop-packaging[rubocop-packaging] on GitHub.
+* Make your feature addition or bug fix in a feature branch.
+* Include a https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[good description]
+  of your changes.
+* Push your feature branch to GitHub.
+* And finally, send a https://help.github.com/articles/using-pull-requests[pull request].

--- a/README.adoc
+++ b/README.adoc
@@ -109,16 +109,22 @@ https://wiki.debian.org/Schroot[schroot], et al) and whilst doing so, the build 
 `Invalid gemspec in [<gem_name>.gemspec]: No such file or directory - git`
 
 And adding `git` as a dependency for each of the Ruby packaging is something that is not right
-and definitely not recommended.
+and definitely not recommended. Besides, the source package consists of released tarballs
+(usually downloaded from GitHub/GitLab releases page or converted from the `.gem` file,
+obtained using `gem fetch foo`), which is extracted during build. So even if we add `git` as
+a build dependency, it would still fail as the Debian package source tree is *not a git repo*.
+Even when the package is maintained in git, it is uploaded as tarballs to the archive without
+any version control information.
 
-Therefore, the other way is to patch out the usage of `git` and use some plain Ruby
-alternatives like `Dir` or `Dir.glob` or even `Rake::FileList`.
+Therefore, the only way forward here is to patch out the usage of `git` and use some plain Ruby
+alternatives like `Dir` or `Dir.glob` or even `Rake::FileList` whilst doing the Debian
+maintenance.
 
 There's not only Debian or other OS packaging situation/examples, but also a couple of others,
 for instance:
 
 * `ruby-core` as part of their CI system runs their test suite against an unpackaged Ruby
-  tarball which doesn't have a `.git` folders. That means they needed to overwrite the
+  tarball which doesn't have a `.git` directory. That means they needed to overwrite the
   bundler gemspec to not use git. +
   Actually, not anymore, https://github.com/rubygems/bundler/pull/6985[since git has been removed from bundler's gemspec].
 
@@ -129,9 +135,9 @@ for instance:
   `gem "foo", git: "https://github.com/has-git-in-gemspec/foo"`
 
 Originally, `git ls-files` inside the default gemspec template was designed so that users
-publishing their first gem wouldn't unintentionally publish artifacts to it. +
-Now that `bundler` won't let you release if you have uncommitted stuff in your working
-repository, the risk is quite lower (if none at all!).
+publishing their first gem wouldn't unintentionally publish artifacts to it.
+Recent versions of bundler won't let you release if you have uncommitted files in your
+working directory, so that risk is lower.
 
 ==== Examples [[gemspec-git-examples]]
 
@@ -187,19 +193,22 @@ Avoid using `require_relative` with relative path to lib. Use `require` instead.
 
 ==== Need [[require-relative-to-lib-need]]
 
-As mentioned earlier, packages in Debian are built in a clean environment. After building them,
-we also run the tests with the `lib/` directory removed to force those tests to use the
-library installed globally via the Debian package. +
-We do so because we want to ensure that the library is loaded from the system location and not
-from the source tree and that it works like it is intended to.
+Debian has a https://ci.debian.net/[testing infrastructure] that is designed to test packages
+in their installed form, i.e., closer to how an end-user would use it than to how a developer
+working against it. For this to work, the test-suite must load code that's installed
+system-wide, instead of the code in the source tree. Using `require_relative` from the tests
+into the `lib` directory makes that impossible, but it also makes the test look less like
+client-code that would use the code in your gem. Therefore, we recommend that test code uses
+the main library code without `require_relative`.
 
 Therefore, when one uses a relative path, we end up getting a `LoadError`, stating: +
 `cannot load such file -- /<<PKGBUILDDIR>>/foo`.
 
-Of course, that said, with this cop, we don't intend to disregard the usage of `require_relative`
-in general. Not at all! It is still recommended but we just add one tiny exception to it. +
-That is, avoid using `require_relative` with a relative path to `lib/` in your tests. That's
-it, that's all we ask!
+We want to emphasize that *there is nothing wrong* with using `require_relative` inside `lib/`,
+it's just using it from your test code to the `lib` directory prevents the "test the library
+installed system-wide" use case.
+
+Therefore, it is still recommended to use `require_relative` with just this exception to it.
 
 ==== Examples [[require-relative-to-lib-examples]]
 
@@ -219,7 +228,7 @@ require 'foo.rb'
 
 # good
 require_relative 'spec_helper'
-require_relative 'foo/bar'
+require_relative 'spec/foo/bar'
 ----
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -60,9 +60,8 @@ gem install rubocop-packaging
 == How To Read This Guide
 
 The guide is separated into sections based on the different cops that the Packaging extension
-provides. +
-There was an attempt to explicitly mention everything so if anything is still unclear, feel
-free to open an issue asking for further clarity.
+provides. There was an attempt to explicitly mention everything so if anything is still
+unclear, feel free to open an issue asking for further clarity.
 
 
 == A Living Document
@@ -83,8 +82,8 @@ upstream maintainers and we're collaborating to try to make things easier for OS
 while not compromising the experience for upstream maintainers.
 
 As a result, we're working on this RuboCop extension to enforce a set of best practices that
-upstream maintainers can follow to make the lives of packagers easier. +
-And that is how `rubocop-packaging` is born!
+upstream maintainers can follow to make the lives of packagers easier. And that is how
+`rubocop-packaging` is born!
 
 
 == Cops Description
@@ -130,8 +129,8 @@ for instance:
 
 * If you build your application on a bare docker image without git, and you are pointing to
   a git sourced gem that uses git on its gemspec, you'll get:
-  `No such file or directory - git ls-files (Errno::ENOENT)` warnings all around. +
-  For example, if you use this in your Gemfile: +
+  `No such file or directory - git ls-files (Errno::ENOENT)` warnings all around. For
+  example, if you use this in your Gemfile: +
   `gem "foo", git: "https://github.com/has-git-in-gemspec/foo"`
 
 Originally, `git ls-files` inside the default gemspec template was designed so that users
@@ -236,8 +235,8 @@ require_relative 'spec/foo/bar'
 
 The guide is still a work in progress - new cops are being added, existing ones are being
 refactored. And whilst doing so, some bits might need a little more polishing and
-paraphrasing to make things clearer. +
-Improving such guidelines is a great (and simple way) to help the Ruby community!
+paraphrasing to make things clearer. Improving such guidelines is a great (and simple way)
+to help the Ruby community!
 
 Also, nothing written in this guide is set in stone. We desire to work together with
 everyone interested in Ruby coding style, so that we could ultimately create a resource that
@@ -268,17 +267,18 @@ is licensed under a http://creativecommons.org/licenses/by/3.0/deed.en_US[Creati
 == Spread the Word
 
 A community-driven style guide is of little use to a community that doesn't know about its
-existence. Tweet about the guide, share it with your friends and colleagues. +
-Every comment, suggestion, or opinion we get, makes the guide a little bit better.
-And we want to have the best possible guide, don't we?
+existence. Tweet/toot about the guide, share it with your friends and colleagues. Every
+comment, suggestion, or opinion we get, makes the guide a little bit better. And we want to
+have the best possible guide, don't we?
 
 
 == Credits
 
 This guide has been put together with the help of our experienced Ruby team in Debian. So a
 huge thanks to all of them and their work. Particularly, https://github.com/terceiro[Antonio Terceiro],
-who has helped a lot in putting all this together in the best possible way! +
-Besides, a huge thanks to https://github.com/deivid-rodriguez[David Rodríguez], an upstream
+who has helped a lot in putting all this together in the best possible way!
+
+And also a huge thanks to https://github.com/deivid-rodriguez[David Rodríguez], an upstream
 maintainer of Bundler and RubyGems, for collaborating on this and extending his help to try
 to make things easier for OS packagers while not compromising the experience for upstream
 maintainers (which is very important!).

--- a/README.adoc
+++ b/README.adoc
@@ -143,6 +143,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- spec/*`.split('\n')
 end
 
+# good
+Gem::Specification.new do |spec|
+  spec.files         = Dir['lib/**/*', 'LICENSE', 'README.md']
+  spec.test_files    = Dir['spec/**/*']
+end
+
 # bad
 Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
@@ -150,22 +156,16 @@ Gem::Specification.new do |spec|
   end
 end
 
+# good
+Gem::Specification.new do |spec|
+  spec.files         = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
+end
+
 # bad
 Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split('\n')
   spec.test_files    = `git ls-files -- test/{functional,unit}/*`.split('\n')
   spec.executables   = `git ls-files -- bin/*`.split('\n').map { |f| File.basename(f) }
-end
-
-# good
-Gem::Specification.new do |spec|
-  spec.files         = Dir['lib/**/*', 'LICENSE', 'README.md']
-  spec.test_files    = Dir['spec/**/*']
-end
-
-# good
-Gem::Specification.new do |spec|
-  spec.files         = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
 end
 
 # good
@@ -208,11 +208,11 @@ it, that's all we ask!
 # bad
 require_relative '../../lib/foo/bar'
 
-# bad
-require_relative 'lib/foo.rb'
-
 # good
 require 'foo/bar'
+
+# bad
+require_relative 'lib/foo.rb'
 
 # good
 require 'foo.rb'

--- a/README.adoc
+++ b/README.adoc
@@ -175,3 +175,49 @@ Gem::Specification.new do |spec|
   spec.executables   = Dir.glob('bin/*').map { |f| File.basename(f) }
 end
 ----
+
+
+=== Relative Require To Lib [[require-relative-to-lib]]
+
+About the `RelativeRequireToLib` cop:
+
+==== Rationale [[require-relative-to-lib-rationale]]
+
+Avoid using `require_relative` with relative path to lib. Use `require` instead.
+
+==== Need [[require-relative-to-lib-need]]
+
+As mentioned earlier, packages in Debian are built in a clean environment. After building them,
+we also run the tests with the `lib/` directory removed to force those tests to use the
+library installed globally via the Debian package. +
+We do so because we want to ensure that the library is loaded from the system location and not
+from the source tree and that it works like it is intended to.
+
+Therefore, when one uses relative path, we end up getting a `LoadError`, stating: +
+`cannot load such file -- /<<PKGBUILDDIR>>/foo`.
+
+Of course, that said, with this cop, we don't intend to disregard the usasge of `require_relative`
+in general. Not at all! It is still recommended but we just add one tiny exception to it. +
+That is, avoid using `require_relative` with relative path to `lib/` in your tests. That's
+it, that's all we ask!
+
+==== Examples [[require-relative-to-lib-examples]]
+
+[source,ruby]
+----
+# bad
+require_relative '../../lib/foo/bar'
+
+# bad
+require_relative 'lib/foo.rb'
+
+# good
+require 'foo/bar'
+
+# good
+require 'foo.rb'
+
+# good
+require_relative 'spec_helper'
+require_relative 'foo/bar'
+----

--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ And that is how `rubocop-packaging` is born!
 Listed below are the cops provided by the `Packaging` extension, describing the need to write
 and enforce it and how is it problematic on the Debian (downstream) side.
 
-=== Gemspec Git [[gemspec-git]]
+=== GemspecGit: Using git in gemspec [[gemspec-git]]
 
 About the `GemspecGit` cop:
 
@@ -183,7 +183,7 @@ end
 ----
 
 
-=== Relative Require To Lib [[require-relative-to-lib]]
+=== RelativeRequireToLib: Using require_relative from test code into lib/ [[require-relative-to-lib]]
 
 About the `RelativeRequireToLib` cop:
 

--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ using the following commands:
 asciidoctor-pdf -a allow-uri-read README.adoc
 
 # Generates README.html
-asciidoctor
+asciidoctor README.adoc
 ----
 
 [TIP]
@@ -71,3 +71,107 @@ This guide is a work in progress - existing guidelines are constantly being impr
 guidelines are being added, and occasionally some guidelines would get removed.
 
 
+== Why Packaging Extension?
+
+The Debian Ruby team has a lot of experience in packaging and maintaining Ruby libraries and
+applications for Debian. During this work, they identified several issues in upstream codebases
+that makes it difficult to build a Debian package straight out of those Ruby gems (shipped via
+https://rubygems.org[rubygems]).
+
+The Debian developers (downstream maintainers) have been in touch with the RubyGems and other
+upstream maintainers and we're collaborating to try to make things easier for OS packagers
+while not compromising the experience for upstream maintainers.
+
+As a result, we're working on this RuboCop extension to enforce a set of best practices that
+upstream maintainers can follow to make lifes of packagers easier. +
+And that is how `rubocop-packaging` is born!
+
+
+== Cops Description
+
+Listed below are the cops provided by the `Packaging` extension, describing the need to write
+and enforce it and how is it problematic on the Debian (downstream) side.
+
+=== Gemspec Git [[gemspec-git]]
+
+About the `GemspecGit` cop:
+
+==== Rationale [[gemspec-git-rationale]]
+
+Avoid using `git ls-files` to produce lists of files. Downstreams often need to build your
+package in an environment that does not have git (on purpose). Instead, use some
+pure Ruby alternative, like `Dir` or `Dir.glob`.
+
+==== Need [[gemspec-git-need]]
+
+Packages in Debian are built in a clean environment (https://wiki.debian.org/sbuild[sbuild],
+https://wiki.debian.org/Schroot[schroot], et al) and whilst doing so, the build fails with: +
+`Invalid gemspec in [<gem_name>.gemspec]: No such file or directory - git`
+
+And adding `git` as a dependency for each of the Ruby packaging is something that is not right
+and definitely not recommended.
+
+Therefore, the other way is to patch out the usage of `git` and use some plain Ruby alternative
+like `Dir` or `Dir.glob` or even `Rake::FileList`.
+
+There's not only Debian or other OS packaging situation/examples, but also a couple others,
+for instance:
+
+* `ruby-core` as part of their CI system runs their test suite against an unpackaged Ruby
+  tarball which doesn't have a `.git` folders. That means they needed to overwrite the
+  bundler gemspec to not use git. +
+  Actually, not anymore, https://github.com/rubygems/bundler/pull/6985[since git has been removed from bundler's gemspec].
+
+* If you build your application on a bare docker image without git, and you are pointing to
+  a git sourced gem that uses git on its gemspec, you'll get:
+  `No such file or directory - git ls-files (Errno::ENOENT)` warnings all around. +
+  For example, if you use this in your Gemfile: +
+  `gem "foo", git: "https://github.com/has-git-in-gemspec/foo"`
+
+Originally, `git ls-files` inside the default gemspec template was designed so that users
+publishing their first gem wouldn't unintentionally publish artifacts to it. +
+Now that `bundler` won't let you release if you have uncommitted stuff in your working
+repository, the risk is quite lower (if none at all!).
+
+==== Examples [[gemspec-git-examples]]
+
+[source,ruby]
+----
+# bad
+Gem::Specification.new do |spec|
+  spec.files         = `git ls-files`.split('\n')
+  spec.test_files    = `git ls-files -- spec/*`.split('\n')
+end
+
+# bad
+Gem::Specification.new do |spec|
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split('\\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+end
+
+# bad
+Gem::Specification.new do |spec|
+  spec.files         = `git ls-files`.split('\n')
+  spec.test_files    = `git ls-files -- test/{functional,unit}/*`.split('\n')
+  spec.executables   = `git ls-files -- bin/*`.split('\n').map { |f| File.basename(f) }
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.files         = Dir['lib/**/*', 'LICENSE', 'README.md']
+  spec.test_files    = Dir['spec/**/*']
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.files         = Rake::FileList['**/*'].exclude(*File.read('.gitignore').split)
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.files         = Dir.glob('lib/**/*')
+  spec.test_files    = Dir.glob('test/{functional,test}/*')
+  spec.executables   = Dir.glob('bin/*').map { |f| File.basename(f) }
+end
+----

--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,7 @@ ____
 Role models are important.
 ____
 
+
 This Packaging style guide outlines the recommended best practices for real-world programmers
 to write code that can be maintained both, upstream and downstream.
 
@@ -54,3 +55,19 @@ on this style guide.
 gem install rubocop-packaging
 ----
 ====
+
+
+== How To Read This Guide
+
+The guide is separated into sections based on the different cops that the Packaging extension
+provides. +
+There was an attempt to explicitly mention everything so if anything is still unclear, feel
+free to open an issue asking for further clarity.
+
+
+== A Living Document
+
+This guide is a work in progress - existing guidelines are constantly being improved, new
+guidelines are being added, and occasionally some guidelines would get removed.
+
+

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,56 @@
+= The Packaging Style Guide
+:idprefix:
+:idseparator: -
+:sectanchors:
+:sectlinks:
+:toc: preamble
+:toclevels: 1
+ifndef::backend-pdf[]
+:toc-title: pass:[<h2>Table of Contents</h2>]
+endif::[]
+:source-highlighter: rouge
+
+== Introduction
+
+[quote, Officer Alex J. Murphy / RoboCop]
+____
+Role models are important.
+____
+
+This Packaging style guide outlines the recommended best practices for real-world programmers
+to write code that can be maintained both, upstream and downstream.
+
+You can generate a PDF copy of this guide using https://asciidoctor.org/docs/asciidoctor-pdf/[AsciiDoctor PDF],
+and an HTML copy https://asciidoctor.org/docs/convert-documents/#converting-a-document-to-html[with] https://asciidoctor.org/#installation[AsciiDoctor]
+using the following commands:
+
+[source,shell]
+----
+# Generates README.pdf
+asciidoctor-pdf -a allow-uri-read README.adoc
+
+# Generates README.html
+asciidoctor
+----
+
+[TIP]
+====
+Install the `rouge` gem to get nice syntax highlighting in the generated document.
+
+[source,shell]
+----
+gem install rouge
+----
+====
+
+[TIP]
+====
+https://github.com/rubocop-hq/rubocop[RuboCop], a static code analyzer (linter) and formatter,
+has a https://github.com/utkarsh2102/rubocop-packaging[`rubocop-packaging`] extension, based
+on this style guide.
+
+[source,shell]
+----
+gem install rubocop-packaging
+----
+====

--- a/README.adoc
+++ b/README.adoc
@@ -254,3 +254,11 @@ It's easy, just follow the contribution guidelines below:
 
 image:https://i.creativecommons.org/l/by/3.0/88x31.png[Creative Commons License] This work
 is licensed under a http://creativecommons.org/licenses/by/3.0/deed.en_US[Creative Commons Attribution 3.0 Unported License].
+
+
+== Spread the Word
+
+A community-driven style guide is of little use to a community that doesn't know about its
+existence. Tweet about the guide, share it with your friends and colleagues. +
+Every comment, suggestion, or opinion we get, makes the guide a little bit better.
+And we want to have the best possible guide, don't we?

--- a/README.adoc
+++ b/README.adoc
@@ -262,3 +262,14 @@ A community-driven style guide is of little use to a community that doesn't know
 existence. Tweet about the guide, share it with your friends and colleagues. +
 Every comment, suggestion, or opinion we get, makes the guide a little bit better.
 And we want to have the best possible guide, don't we?
+
+
+== Credits
+
+This guide has been put together with the help of our experienced Ruby team in Debian. So a
+huge thanks to all of them and their work. Particularly, https://github.com/terceiro[Antonio Terceiro],
+who has helped a lot in putting all this together in the best possible way! +
+Besides, a huge thanks to https://github.com/deivid-rodriguez[David Rodríguez], an upstream
+maintainer of Bundler and RubyGems, for collaborating on this and extending his help to try
+to make things easier for OS packagers while not compromising the experience for upstream
+maintainers (which is very important!).

--- a/README.adoc
+++ b/README.adoc
@@ -248,3 +248,9 @@ It's easy, just follow the contribution guidelines below:
   of your changes.
 * Push your feature branch to GitHub.
 * And finally, send a https://help.github.com/articles/using-pull-requests[pull request].
+
+
+== License
+
+image:https://i.creativecommons.org/l/by/3.0/88x31.png[Creative Commons License] This work
+is licensed under a http://creativecommons.org/licenses/by/3.0/deed.en_US[Creative Commons Attribution 3.0 Unported License].

--- a/README.adoc
+++ b/README.adoc
@@ -75,7 +75,7 @@ guidelines are being added, and occasionally some guidelines would get removed.
 
 The Debian Ruby team has a lot of experience in packaging and maintaining Ruby libraries and
 applications for Debian. During this work, they identified several issues in upstream codebases
-that makes it difficult to build a Debian package straight out of those Ruby gems (shipped via
+that make it difficult to build a Debian package straight out of those Ruby gems (shipped via
 https://rubygems.org[rubygems]).
 
 The Debian developers (downstream maintainers) have been in touch with the RubyGems and other
@@ -83,7 +83,7 @@ upstream maintainers and we're collaborating to try to make things easier for OS
 while not compromising the experience for upstream maintainers.
 
 As a result, we're working on this RuboCop extension to enforce a set of best practices that
-upstream maintainers can follow to make lifes of packagers easier. +
+upstream maintainers can follow to make the lives of packagers easier. +
 And that is how `rubocop-packaging` is born!
 
 
@@ -100,7 +100,7 @@ About the `GemspecGit` cop:
 
 Avoid using `git ls-files` to produce lists of files. Downstreams often need to build your
 package in an environment that does not have git (on purpose). Instead, use some
-pure Ruby alternative, like `Dir` or `Dir.glob`.
+pure Ruby alternatives, like `Dir` or `Dir.glob`.
 
 ==== Need [[gemspec-git-need]]
 
@@ -111,10 +111,10 @@ https://wiki.debian.org/Schroot[schroot], et al) and whilst doing so, the build 
 And adding `git` as a dependency for each of the Ruby packaging is something that is not right
 and definitely not recommended.
 
-Therefore, the other way is to patch out the usage of `git` and use some plain Ruby alternative
-like `Dir` or `Dir.glob` or even `Rake::FileList`.
+Therefore, the other way is to patch out the usage of `git` and use some plain Ruby
+alternatives like `Dir` or `Dir.glob` or even `Rake::FileList`.
 
-There's not only Debian or other OS packaging situation/examples, but also a couple others,
+There's not only Debian or other OS packaging situation/examples, but also a couple of others,
 for instance:
 
 * `ruby-core` as part of their CI system runs their test suite against an unpackaged Ruby
@@ -193,12 +193,12 @@ library installed globally via the Debian package. +
 We do so because we want to ensure that the library is loaded from the system location and not
 from the source tree and that it works like it is intended to.
 
-Therefore, when one uses relative path, we end up getting a `LoadError`, stating: +
+Therefore, when one uses a relative path, we end up getting a `LoadError`, stating: +
 `cannot load such file -- /<<PKGBUILDDIR>>/foo`.
 
-Of course, that said, with this cop, we don't intend to disregard the usasge of `require_relative`
+Of course, that said, with this cop, we don't intend to disregard the usage of `require_relative`
 in general. Not at all! It is still recommended but we just add one tiny exception to it. +
-That is, avoid using `require_relative` with relative path to `lib/` in your tests. That's
+That is, avoid using `require_relative` with a relative path to `lib/` in your tests. That's
 it, that's all we ask!
 
 ==== Examples [[require-relative-to-lib-examples]]


### PR DESCRIPTION
This PR covers most of the reasons why the `Packaging` extension was born and explains the cops that are provided by the `Packaging` extension, describing the need to write and enforce it and how is it problematic on the Debian (downstream) side.

Resloves and relates to: https://github.com/utkarsh2102/rubocop-packaging/issues/3

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>