### PR TITLE
Remove `spec.test_files` from The Packaging Style Guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -132,14 +132,12 @@ working directory, so that risk is lower.
 ----
 # bad
 Gem::Specification.new do |spec|
-  spec.files         = `git ls-files`.split("\n")
-  spec.test_files    = `git ls-files -- spec`.split("\n")
+  spec.files = `git ls-files`.split("\n")
 end
 
 # good
 Gem::Specification.new do |spec|
-  spec.files         = Dir["lib/**/*", "LICENSE", "README.md"]
-  spec.test_files    = Dir["spec/**/*"]
+  spec.files = Dir["lib/**/*", "LICENSE", "README.md"]
 end
 
 # bad
@@ -153,21 +151,19 @@ end
 require "rake/file_list"
 
 Gem::Specification.new do |spec|
-  spec.files         = Rake::FileList["**/*"].exclude(*File.read(".gitignore").split)
+  spec.files = Rake::FileList["**/*"].exclude(*File.read(".gitignore").split)
 end
 
 # bad
 Gem::Specification.new do |spec|
-  spec.files         = `git ls-files -- lib/`.split("\n")
-  spec.test_files    = `git ls-files -- test/{functional,unit}/*`.split("\n")
-  spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  spec.files       = `git ls-files -- lib/`.split("\n")
+  spec.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 end
 
 # good
 Gem::Specification.new do |spec|
-  spec.files         = Dir.glob("lib/**/*")
-  spec.test_files    = Dir.glob("test/{functional,test}/*")
-  spec.executables   = Dir.glob("bin/*").map{ |f| File.basename(f) }
+  spec.files       = Dir.glob("lib/**/*")
+  spec.executables = Dir.glob("bin/*").map{ |f| File.basename(f) }
 end
 ----
 


### PR DESCRIPTION
Follow up to https://github.com/rubocop/rubocop/issues/10065#issuecomment-913286909 and https://github.com/utkarsh2102/rubocop-packaging/pull/41.